### PR TITLE
Optionally opening istream as binary

### DIFF
--- a/src/ofxZipArchive.cpp
+++ b/src/ofxZipArchive.cpp
@@ -41,11 +41,12 @@ bool ofxZipArchive::compress(string folderPath, string zipPath, bool recursive, 
 
 
 // ----------------------------------------------------------
-bool ofxZipArchive::open(string zipPath) {
+bool ofxZipArchive::open(string zipPath, bool binary) {
     zipPath = ofToDataPath(zipPath);
     ofLogNotice("ofxZipArchive") << "Opening " << zipPath;
     
-    infile.open(zipPath.c_str());
+	ios_base::openmode mode = binary ? ifstream::binary : ios_base::in;
+	infile.open(zipPath.c_str(), std::ios_base::binary);
     if(!infile.good()) {
         ofLogError("ofZipArchive") << "Couldn't open " << zipPath;
         return false;

--- a/src/ofxZipArchive.h
+++ b/src/ofxZipArchive.h
@@ -26,8 +26,8 @@
 class ofxZipArchive {
 public:
     ofxZipArchive():bOpened(false){}
-    
-    bool open(string zipPath);
+
+	bool open(string zipPath, bool binary = false);
     vector<string> list();
     ofBuffer getFile(string fileName);
     bool unzipTo(string destination);


### PR DESCRIPTION
Opening zipped binary files such as images (.png .jpg etc) failed because the istream open mode used ::in as default instead of explicitly setting ::binary.

Set a optional parameter to load as binary.
